### PR TITLE
Hot fix

### DIFF
--- a/Encounter Me.Api/Controllers/TrailGenerationController.cs
+++ b/Encounter Me.Api/Controllers/TrailGenerationController.cs
@@ -64,7 +64,7 @@ namespace Encounter_Me.Api.Controllers
             {
                 Coordinate coord = coordinates.ToArray()[i];
 
-                trailResultGeojson += ("[" + coord.Lon.ToString() + ", " + coord.Lat.ToString() + "]");
+                trailResultGeojson += ("[" + coord.Lon.ToString().Replace(',', '.') + ", " + coord.Lat.ToString().Replace(',', '.') + "]");
 
                 if (i != coordinates.Count()-1)
                 {

--- a/Encounter Me.Api/Trail generation Utilities/Coordinate.cs
+++ b/Encounter Me.Api/Trail generation Utilities/Coordinate.cs
@@ -18,7 +18,7 @@ namespace Encounter_Me.Api.Trail_generation_Utilities
 
         public override string ToString()
         {
-            return Lat.ToString() + "," + Lon.ToString();
+            return Lat.ToString().Replace(',', '.') + "," + Lon.ToString().Replace(',', '.');
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
Problems arise with decimal symbol parsing. For some reason `.ToString()` converts `double` to floating point value with decimal symbol not '.' but ',' for this reason data is not fetched from Google maps directions API.